### PR TITLE
Fixed `yii\mongodb\Collection::dropIndex()` unable to drop index spec…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Yii Framework 2 mongodb extension Change Log
 -----------------------
 
 - Bug #241: Fixed `yii\mongodb\Command::aggregate()` without 'cursor' option produces error on MongoDB Server 3.6 (Lisio, klimov-paul)
+- Bug #247: Fixed `yii\mongodb\Collection::dropIndex()` unable to drop index specified with sort via index plugin (klimov-paul)
 
 
 2.1.5 November 03, 2017

--- a/Collection.php
+++ b/Collection.php
@@ -179,9 +179,17 @@ class Collection extends BaseObject
         $existingIndexes = $this->listIndexes();
 
         $indexKey = $this->database->connection->getQueryBuilder()->buildSortFields($columns);
-
         foreach ($existingIndexes as $index) {
             if ($index['key'] == $indexKey) {
+                $this->database->createCommand()->dropIndexes($this->name, $index['name']);
+                return true;
+            }
+        }
+
+        // Index plugin usage such as 'text' may cause unpredictable index 'key' structure, thus index name should be used
+        $indexName = $this->database->connection->getQueryBuilder()->generateIndexName($indexKey);
+        foreach ($existingIndexes as $index) {
+            if ($index['name'] === $indexName) {
                 $this->database->createCommand()->dropIndexes($this->name, $index['name']);
                 return true;
             }

--- a/QueryBuilder.php
+++ b/QueryBuilder.php
@@ -171,10 +171,11 @@ class QueryBuilder extends BaseObject
 
     /**
      * Generates index name for the given column orders.
+     * Columns should be normalized using [[buildSortFields()]] before being passed to this method.
      * @param array $columns columns with sort order.
      * @return string index name.
      */
-    private function generateIndexName($columns)
+    public function generateIndexName($columns)
     {
         $parts = [];
         foreach ($columns as $column => $order) {

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -420,6 +420,24 @@ class CollectionTest extends TestCase
     }
 
     /**
+     * @depends testDropIndex
+     * @see https://github.com/yiisoft/yii2-mongodb/issues/247
+     */
+    public function testDropIndexWithPlugin()
+    {
+        $collection = $this->getConnection()->getCollection('customer');
+
+        $columns = [
+            'name' => 'text'
+        ];
+        $collection->createIndex($columns);
+
+        $this->assertTrue($collection->dropIndex($columns));
+        $indexInfo = $collection->listIndexes();
+        $this->assertEquals(1, count($indexInfo));
+    }
+
+    /**
      * @depends testCreateIndex
      */
     public function testDropAllIndexes()


### PR DESCRIPTION
…ified with sort via index plugin

| Q             | A
| ------------- | ---
| Is bugfix?    | yes/no
| New feature?  | yes/no
| Breaks BC?    | yes/no
| Tests pass?   | yes/no
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
